### PR TITLE
feat: Drawer Tweaks

### DIFF
--- a/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
+++ b/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
@@ -451,6 +451,7 @@ function mod.setup(_)
   })
 
   vim.api.nvim_create_autocmd('BufWipeout', {
+    desc = 'nvim-drawer: Cleanup when buffer is wiped out',
     group = drawer_augroup,
     callback = function(event)
       local bufname = event.file

--- a/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
+++ b/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
@@ -442,6 +442,21 @@ function mod.setup(_)
     end,
   })
 
+  vim.api.nvim_create_autocmd('BufWipeout', {
+    group = drawer_augroup,
+    callback = function(event)
+      -- local bufname = vim.fn.bufname(event.buf)
+      local bufname = event.file
+      for _, instance in ipairs(instances) do
+        if instance.is_buffer(bufname) then
+          instance.state.buffers = vim.tbl_filter(function(b)
+            return b ~= bufname
+          end, instance.state.buffers)
+        end
+      end
+    end,
+  })
+
   vim.api.nvim_create_autocmd('WinClosed', {
     desc = 'nvim-drawer: Close tab when all non-drawers are closed',
     group = drawer_augroup,

--- a/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
+++ b/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
@@ -453,13 +453,28 @@ function mod.setup(_)
   vim.api.nvim_create_autocmd('BufWipeout', {
     group = drawer_augroup,
     callback = function(event)
-      -- local bufname = vim.fn.bufname(event.buf)
       local bufname = event.file
       for _, instance in ipairs(instances) do
         if instance.is_buffer(bufname) then
-          instance.state.buffers = vim.tbl_filter(function(b)
+          local new_buffers = vim.tbl_filter(function(b)
             return b ~= bufname
           end, instance.state.buffers)
+
+          instance.state.is_open = false
+          instance.state.previous_bufname = new_buffers[#new_buffers] or ''
+          instance.state.buffers = new_buffers
+
+          -- TODO Not sure if this is useful. Technically, the drawer will be
+          -- "closed", like, it's not open any more.
+          -- But not sure if BufWipeout will happen anyways via whatever people
+          -- do with their drawers, and if .close() is properly called, then
+          -- these callbacks would be doubled-up.
+          -- if instance.opts.on_will_close then
+          --   instance.opts.on_will_close()
+          -- end
+          -- if instance.opts.on_did_close then
+          --   instance.opts.on_did_close()
+          -- end
         end
       end
     end,

--- a/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
+++ b/src/nvim/nvim-drawer/lua/nvim-drawer/init.lua
@@ -11,6 +11,10 @@ local mod = {}
 --- @field position 'left' | 'right' | 'top' | 'bottom'
 --- Called before a buffer is created. This is called very rarely.
 --- @field on_will_create_buffer? fun(bufname: string): nil
+--- Called after a buffer is created. This is called very rarely.
+--- @field on_did_create_buffer? fun(bufname: string): nil
+--- Called before a buffer is opened.
+--- @field on_will_open_buffer? fun(bufname: string): nil
 --- Called after a buffer is opened.
 --- @field on_did_open_buffer? fun(bufname: string): nil
 --- Called before the splt is created.
@@ -178,10 +182,14 @@ function mod.create_drawer(opts)
   function instance.switch_window_to_buffer(bufname)
     local bufnr = vim.fn.bufnr(bufname)
 
+    try_callback('on_will_open_buffer', bufname)
+
     if bufnr == -1 then
       try_callback('on_will_create_buffer', bufname)
 
       vim.cmd('file ' .. bufname)
+
+      try_callback('on_did_create_buffer', bufname)
     else
       vim.cmd('buffer ' .. bufname)
     end


### PR DESCRIPTION
- Fixes an issue with nvim-drawer when a buffer is removed. Think when typing `exit` or `^D` into a terminal. That buffer gets wiped out, but as far as nvim-drawer knew, it still existed. This caused many oddities when switching tabs.
- Adds more callbacks in case they're ever needed.